### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,22 +3,22 @@ django-shared
 
 |Downloads| |Version| |Wheel| |Egg| |Format| |License|
 
-.. |Downloads| image:: https://pypip.in/download/django-shared/badge.png
+.. |Downloads| image:: https://img.shields.io/pypi/dm/django-shared.svg
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: Downloads
-.. |Version| image:: https://pypip.in/version/django-shared/badge.png
+.. |Version| image:: https://img.shields.io/pypi/v/django-shared.svg
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: Latest Version
-.. |Wheel| image:: https://pypip.in/wheel/django-shared/badge.png
+.. |Wheel| image:: https://img.shields.io/pypi/wheel/django-shared.svg
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: Wheel Status
 .. |Egg| image:: https://pypip.in/egg/django-shared/badge.png
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: Egg Status
-.. |Format| image:: https://pypip.in/format/django-shared/badge.png
+.. |Format| image:: https://img.shields.io/pypi/format/django-shared.svg
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: Download format
-.. |License| image:: https://pypip.in/license/django-shared/badge.png
+.. |License| image:: https://img.shields.io/pypi/l/django-shared.svg
     :target: https://pypi.python.org/pypi/django-shared/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-shared))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-shared`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.